### PR TITLE
Should have a new section Overview

### DIFF
--- a/input/fileencryption.xml
+++ b/input/fileencryption.xml
@@ -141,7 +141,9 @@
       that element is implemented. It is allowable for some elements in a component to be
       implemented by the TOE, while other elements in that same component may be implemented by
       the platform; in these cases, further guidance is given in the application notes and
-      Supporting Documentation.<h:br/>  <h:br/> In some cases, the TOE vendor will have to provide specific
+      Supporting Documentation.<h:br/>  <h:br/> 
+      
+      <h:b>Operational Guidance (optional)</h:b> <h:br/> In some cases, the TOE vendor will have to provide specific
       configuration guidance for the Operational Environment to enable the TOE to meet its
       security objectives. These include:<h:br/> For non-mobile systems:<h:br/>
       <h:ul>


### PR DESCRIPTION
Based on how the rest of this section is written, the sentence starting with "In some cases..." should have its own section, something like "Operational Guidance".

This is a suggestion for how to do it. Without this though the previous section on Data Authentication goes right into this without a break and it makes the references confusion (since you are still looking at Data Authentication but you are now onto a different topic without a note to the change).